### PR TITLE
feat: persist active network to localStorage

### DIFF
--- a/src/appState/accountState.ts
+++ b/src/appState/accountState.ts
@@ -1,4 +1,5 @@
 import {
+  catchError,
   combineLatest,
   distinctUntilChanged,
   map,
@@ -19,10 +20,7 @@ import { BigNumber } from 'ethers';
 import { filter } from 'rxjs/operators';
 import { gql } from '@apollo/client';
 import { UpdateDataCtx } from './updateStateModel';
-import {
-  replaceUpdatedSigners,
-  updateSignersEvmBindings,
-} from './accountStateUtil';
+import { replaceUpdatedSigners, updateSignersEvmBindings, } from './accountStateUtil';
 import { currentProvider$ } from './providerState';
 import { ReefSigner } from '../state';
 import { apolloClientInstance$, zenToRx } from '../graphql/apollo';
@@ -41,34 +39,36 @@ const signersLocallyUpdatedData$: Observable<ReefSigner[]> = reloadSignersSubj.p
   mergeScan(
     (
       state: {
-          all: ReefSigner[];
-          allUpdated: ReefSigner[];
-          lastUpdated: ReefSigner[];
-        },
-      [updateCtx, signersInjected],
+        all: ReefSigner[];
+        allUpdated: ReefSigner[];
+        lastUpdated: ReefSigner[];
+      },
+      [updateCtx, signersInjected]: [any, ReefSigner[]],
     ): any => {
       const allSignersLatestUpdates = replaceUpdatedSigners(
         signersInjected,
         state.allUpdated,
       );
-      return of(updateCtx.updateActions).pipe(
-        switchMap((updateActions) => updateSignersEvmBindings(
-          updateActions,
-          allSignersLatestUpdates,
-        ).then((lastUpdated) => ({
-          all: replaceUpdatedSigners(
+      return of(updateCtx.updateActions)
+        .pipe(
+          switchMap((updateActions) => updateSignersEvmBindings(
+            updateActions,
             allSignersLatestUpdates,
-            lastUpdated,
-            true,
-          ),
-          allUpdated: replaceUpdatedSigners(
-            state.allUpdated,
-            lastUpdated,
-            true,
-          ),
-          lastUpdated,
-        }))),
-      );
+          )
+            .then((lastUpdated) => ({
+              all: replaceUpdatedSigners(
+                allSignersLatestUpdates,
+                lastUpdated,
+                true,
+              ),
+              allUpdated: replaceUpdatedSigners(
+                state.allUpdated,
+                lastUpdated,
+                true,
+              ),
+              lastUpdated,
+            }))),
+        );
     },
     {
       all: [],
@@ -79,70 +79,86 @@ const signersLocallyUpdatedData$: Observable<ReefSigner[]> = reloadSignersSubj.p
   filter((val: any) => !!val.lastUpdated.length),
   map((val: any): any => val.all),
   startWith([]),
+  catchError(err => {
+    console.log('signersLocallyUpdatedData$ ERROR=', err.message);
+    return of([]);
+  }),
   shareReplay(1),
 );
 
 const signersWithUpdatedBalances$ = combineLatest([
   currentProvider$,
   signersInjected$,
-]).pipe(
-  mergeScan(
-    (
-      state: { unsub: any; balancesByAddressSubj: ReplaySubject<any> },
-      [provider, signers]: [Provider, ReefSigner[]],
-    ) => {
-      if (state.unsub) {
-        state.unsub();
-      }
-      const distinctSignerAddresses = signers
-        .map((s) => s.address)
-        .reduce((distinctAddrList: string[], curr: string) => {
-          if (distinctAddrList.indexOf(curr) < 0) {
-            distinctAddrList.push(curr);
-          }
-          return distinctAddrList;
-        }, []);
-      // eslint-disable-next-line no-param-reassign
-      return provider.api.query.system.account
-        .multi(distinctSignerAddresses, (balances: any[]) => {
-          const balancesByAddr = balances.map(({ data }, index) => ({
-            address: distinctSignerAddresses[index],
-            balance: data.free.toString(),
-          }));
-          state.balancesByAddressSubj.next({
-            balances: balancesByAddr,
-            signers,
+])
+  .pipe(
+    mergeScan(
+      (
+        state: { unsub: any; balancesByAddressSubj: ReplaySubject<any> },
+        [provider, signers]: [Provider, ReefSigner[]],
+      ) => {
+        if (state.unsub) {
+          state.unsub();
+        }
+        const distinctSignerAddresses = signers
+          .map((s) => s.address)
+          .reduce((distinctAddrList: string[], curr: string) => {
+            if (distinctAddrList.indexOf(curr) < 0) {
+              distinctAddrList.push(curr);
+            }
+            return distinctAddrList;
+          }, []);
+        // eslint-disable-next-line no-param-reassign
+        return provider.api.query.system.account
+          .multi(distinctSignerAddresses, (balances: any[]) => {
+            const balancesByAddr = balances.map(({ data }, index) => ({
+              address: distinctSignerAddresses[index],
+              balance: data.free.toString(),
+            }));
+            state.balancesByAddressSubj.next({
+              balances: balancesByAddr,
+              signers,
+            });
+          })
+          .then((unsub) => {
+            // eslint-disable-next-line no-param-reassign
+            state.unsub = unsub;
+            return state;
           });
-        })
-        .then((unsub) => {
-          // eslint-disable-next-line no-param-reassign
-          state.unsub = unsub;
-          return state;
-        });
-    },
-    { unsub: null, balancesByAddressSubj: new ReplaySubject<any>(1) },
-  ),
-  distinctUntilChanged(
-    (prev: any, curr: any): any => prev.balancesByAddressSubj !== curr.balancesByAddressSubj,
-  ),
-  switchMap(
-    (v: {
-      balancesByAddressSubj: Subject<{ balances: any; signers: ReefSigner[] }>;
-    }) => v.balancesByAddressSubj,
-  ),
-  map((balancesAndSigners: { balances: any; signers: ReefSigner[] }) => (!balancesAndSigners.signers
-    ? []
-    : balancesAndSigners.signers.map((sig) => {
-      const bal = balancesAndSigners.balances.find(
-        (b: { address: string; balance: string }) => b.address === sig.address,
-      );
-      if (bal && !BigNumber.from(bal.balance).eq(sig.balance)) {
-        return { ...sig, balance: BigNumber.from(bal.balance) };
-      }
-      return sig;
-    }))),
-  shareReplay(1),
-);
+      },
+      {
+        unsub: null,
+        balancesByAddressSubj: new ReplaySubject<any>(1)
+      },
+    ),
+    distinctUntilChanged(
+      (prev: any, curr: any): any => prev.balancesByAddressSubj !== curr.balancesByAddressSubj,
+    ),
+    switchMap(
+      (v: {
+        balancesByAddressSubj: Subject<{ balances: any; signers: ReefSigner[] }>;
+      }) => v.balancesByAddressSubj,
+    ),
+    map((balancesAndSigners: { balances: any; signers: ReefSigner[] }) => (!balancesAndSigners.signers
+      ? []
+      : balancesAndSigners.signers.map((sig) => {
+        const bal = balancesAndSigners.balances.find(
+          (b: { address: string; balance: string }) => b.address === sig.address,
+        );
+        if (bal && !BigNumber.from(bal.balance)
+          .eq(sig.balance)) {
+          return {
+            ...sig,
+            balance: BigNumber.from(bal.balance)
+          };
+        }
+        return sig;
+      }))),
+    shareReplay(1),
+    catchError(err => {
+      console.log('signersWithUpdatedBalances$ ERROR=', err.message);
+      return of([]);
+    })
+  );
 
 const EVM_ADDRESS_UPDATE_GQL = gql`
   subscription query($accountIds: [String!]!) {
@@ -155,6 +171,7 @@ const EVM_ADDRESS_UPDATE_GQL = gql`
     }
   }
 `;
+
 // eslint-disable-next-line camelcase
 interface AccountEvmAddrData {
   address: string;
@@ -162,104 +179,153 @@ interface AccountEvmAddrData {
   evm_address?: string;
   isEvmClaimed?: boolean;
 }
+
 const indexedAccountValues$ = combineLatest([
   apolloClientInstance$,
   signersInjected$,
-]).pipe(
-  switchMap(([apollo, signers]) => (!signers
-    ? []
-    : zenToRx(
-      apollo.subscribe({
-        query: EVM_ADDRESS_UPDATE_GQL,
-        variables: { accountIds: signers.map((s: any) => s.address) },
-        fetchPolicy: 'network-only',
-      }),
-    ))),
-  map((result: any): AccountEvmAddrData[] => result.data.account),
-  filter((v) => !!v),
-  startWith([]),
-);
+])
+  .pipe(
+    switchMap(([apollo, signers]) => (!signers
+      ? []
+      : zenToRx(
+        apollo.subscribe({
+          query: EVM_ADDRESS_UPDATE_GQL,
+          variables: { accountIds: signers.map((s: any) => s.address) },
+          fetchPolicy: 'network-only',
+        }),
+      ))),
+    map((result: any): AccountEvmAddrData[] => result.data.account),
+    filter((v) => !!v),
+    startWith([]),
+  );
 
 const signersWithUpdatedData$ = combineLatest([
   signersWithUpdatedBalances$,
   signersLocallyUpdatedData$,
   indexedAccountValues$,
-]).pipe(
-  scan(
-    (
-      state: {
-        lastlocallyUpdated: ReefSigner[];
-        lastIndexed: AccountEvmAddrData[];
-        lastSigners: ReefSigner[];
-      },
-      [signers, locallyUpdated, indexed],
-    ) => {
-      let updateBindValues: AccountEvmAddrData[] = [];
-      if (state.lastlocallyUpdated !== locallyUpdated) {
-        updateBindValues = locallyUpdated.map((updSigner) => ({
-          address: updSigner.address,
-          isEvmClaimed: updSigner.isEvmClaimed,
-        }));
-      } else if (state.lastIndexed !== indexed) {
-        updateBindValues = indexed.map((updSigner: AccountEvmAddrData) => ({
-          address: updSigner.address,
-          isEvmClaimed: !!updSigner.evm_address,
-        }));
-      } else {
-        updateBindValues = state.lastSigners.map((updSigner) => ({
-          address: updSigner.address,
-          isEvmClaimed: updSigner.isEvmClaimed,
-        }));
-      }
-      updateBindValues.forEach((updVal: AccountEvmAddrData) => {
-        const signer = signers.find((sig) => sig.address === updVal.address);
-        if (signer) {
-          signer.isEvmClaimed = !!updVal.isEvmClaimed;
+])
+  .pipe(
+    scan(
+      (
+        state: {
+          lastlocallyUpdated: ReefSigner[];
+          lastIndexed: AccountEvmAddrData[];
+          lastSigners: ReefSigner[];
+          signers: ReefSigner[];
+        },
+        [signers, locallyUpdated, indexed],
+      ) => {
+        let updateBindValues: AccountEvmAddrData[] = [];
+        if (state.lastlocallyUpdated !== locallyUpdated) {
+          updateBindValues = locallyUpdated.map((updSigner) => ({
+            address: updSigner.address,
+            isEvmClaimed: updSigner.isEvmClaimed,
+          }));
+        } else if (state.lastIndexed !== indexed) {
+          updateBindValues = indexed.map((updSigner: AccountEvmAddrData) => ({
+            address: updSigner.address,
+            isEvmClaimed: !!updSigner.evm_address,
+          }));
+        } else {
+          updateBindValues = state.lastSigners.map((updSigner) => ({
+            address: updSigner.address,
+            isEvmClaimed: updSigner.isEvmClaimed,
+          }));
         }
-      });
-      return {
-        signers,
-        lastlocallyUpdated: locallyUpdated,
-        lastIndexed: indexed,
-        lastSigners: signers,
-      };
-    },
-    {
-      signers: [],
-      lastlocallyUpdated: [],
-      lastIndexed: [],
-      lastSigners: [],
-    },
-  ),
-  map(({ signers }) => signers),
-);
-
-export const signers$: Observable<ReefSigner[]> = signersWithUpdatedData$;
-
-export const selectAddressSubj: ReplaySubject<string | undefined> = new ReplaySubject<string | undefined>(1);
-signers$.pipe(take(1)).subscribe((signers: any): any => {
-  selectAddressSubj.next(
-    localStorage.getItem('selected_address_reef') || signers[0],
+        updateBindValues.forEach((updVal: AccountEvmAddrData) => {
+          const signer = signers.find((sig) => sig.address === updVal.address);
+          if (signer) {
+            signer.isEvmClaimed = !!updVal.isEvmClaimed;
+          }
+        });
+        return {
+          signers,
+          lastlocallyUpdated: locallyUpdated,
+          lastIndexed: indexed,
+          lastSigners: signers,
+        };
+      },
+      {
+        signers: [],
+        lastlocallyUpdated: [],
+        lastIndexed: [],
+        lastSigners: [],
+      },
+    ),
+    map(({ signers }) => signers),
+    shareReplay(1),
+    catchError(err => {
+      console.log('signersWithUpdatedData$ ERROR=', err.message);
+      return of(null);
+    })
   );
-});
-export const selectedSigner$: Observable<ReefSigner | undefined> = combineLatest([
-  selectAddressSubj.pipe(distinctUntilChanged()),
-  signers$,
-]).pipe(
-  map(([selectedAddress, signers]) => {
-    let foundSigner = signers?.find(
-      (signer: ReefSigner) => signer.address === selectedAddress,
-    );
-    if (!foundSigner) {
-      foundSigner = signers ? signers[0] : undefined;
+
+export const signers$: Observable<ReefSigner[] | null> = signersWithUpdatedData$;
+
+const currentAddressSubj: Subject<string | undefined> = new Subject<string | undefined>();
+export const setCurrentAddress = (address: string|undefined)=> currentAddressSubj.next(address);
+export const currentAddress$: Observable<string | undefined> = currentAddressSubj.asObservable()
+  .pipe(
+    startWith(''),
+    distinctUntilChanged(),
+    shareReplay(1),
+  );
+
+// setting default signer (when signers exist) if no selected address exists
+combineLatest([signers$, currentAddress$])
+  .pipe(take(1))
+  .subscribe(([signers, address]: [ReefSigner[] | null, string]): any => {
+    let saved: string | undefined = address;
+    try {
+      if (!saved) {
+        saved = localStorage?.getItem('selected_address_reef') || undefined;
+      }
+    } catch (e) {
+      // getting error in Flutter: 'The operation is insecure'
+      // console.log('Flutter error=', e.message);
     }
-    if (foundSigner) {
-      localStorage.setItem(
-        'selected_address_reef',
-        foundSigner.address || '',
+
+    if (!saved) {
+      let firstSigner = signers && signers[0] ? signers[0].address : undefined;
+      setCurrentAddress(
+        saved || firstSigner
       );
     }
-    return foundSigner ? { ...foundSigner } : undefined;
-  }),
-  shareReplay(1),
-);
+  });
+
+export const selectedSigner$: Observable<ReefSigner | undefined | null> = combineLatest([
+  currentAddress$,
+  signers$,
+])
+  .pipe(
+    map(([selectedAddress, signers]: [(string | undefined), (ReefSigner[] | null)]) => {
+      if (!selectedAddress) {
+        return undefined;
+      }
+      console.log('lib/SEL SIGNER addr=', selectedAddress, signers?.length);
+      let foundSigner = signers?.find(
+        (signer: ReefSigner) => signer?.address === selectedAddress,
+      );
+      if (!foundSigner) {
+        foundSigner = signers ? signers[0] : undefined;
+      }
+      try {
+        if (foundSigner) {
+          localStorage.setItem(
+            'selected_address_reef',
+            foundSigner.address || '',
+          );
+        }
+      } catch (e) {
+        // getting error in Flutter: 'The operation is insecure'
+        // console.log('Flutter error=',e.message);
+      }
+      return foundSigner ? { ...foundSigner } : undefined;
+    }),
+    catchError((err) => {
+      console.log('selectedSigner$ ERROR=', err.message);
+      return of(null);
+    }),
+    shareReplay(1),
+  );
+

--- a/src/appState/providerState.ts
+++ b/src/appState/providerState.ts
@@ -5,13 +5,14 @@ import { Network } from '../state';
 const providerSubj: ReplaySubject<Provider> = new ReplaySubject<Provider>(1);
 const selectedNetworkSubj: ReplaySubject<Network> = new ReplaySubject<Network>();
 
+export const ACTIVE_NETWORK_LS_KEY = 'reef-app-active-network';
 export const currentProvider$ = providerSubj.asObservable().pipe(shareReplay(1));
 export const setCurrentProvider = (provider: Provider): void => providerSubj.next(provider);
 
 export const currentNetwork$ = selectedNetworkSubj.asObservable();
 export const setCurrentNetwork = (network: Network): void => {
   if (network != null) {
-    localStorage.setItem('reef-app-active-network', JSON.stringify(network));
+    localStorage.setItem(ACTIVE_NETWORK_LS_KEY, JSON.stringify(network));
   }
   selectedNetworkSubj.next(network);
 };

--- a/src/appState/providerState.ts
+++ b/src/appState/providerState.ts
@@ -1,13 +1,13 @@
-import { ReplaySubject } from 'rxjs';
+import { ReplaySubject, shareReplay } from 'rxjs';
 import { Provider } from '@reef-defi/evm-provider';
 import { Network } from '../state';
 
 const providerSubj: ReplaySubject<Provider> = new ReplaySubject<Provider>(1);
 const selectedNetworkSubj: ReplaySubject<Network> = new ReplaySubject<Network>();
 
-export const currentProvider$ = providerSubj.asObservable();
+export const currentProvider$ = providerSubj.asObservable().pipe(shareReplay(1));
 export const setCurrentProvider = (provider: Provider): void => providerSubj.next(provider);
 
-export const currentNetwork$ = selectedNetworkSubj.asObservable();
+export const currentNetwork$ = selectedNetworkSubj.asObservable()
 export const setCurrentNetwork = (network: Network): void => selectedNetworkSubj.next(network);
 currentNetwork$.subscribe((network) => console.log('SELECTED NETWORK=', network.rpcUrl));

--- a/src/appState/tokenState.ts
+++ b/src/appState/tokenState.ts
@@ -1,4 +1,5 @@
 import {
+  catchError,
   combineLatest,
   distinctUntilChanged,
   map,
@@ -163,8 +164,7 @@ const sortReefTokenFirst = (tokens): Token[] => {
   }
   return tokens;
 };
-
-export const selectedSignerTokenBalances$: Observable<Token[]> = combineLatest([
+export const selectedSignerTokenBalances$: Observable<Token[]|null> = combineLatest([
   apolloClientInstance$,
   selectedSigner$,
   currentProvider$,
@@ -219,6 +219,10 @@ export const selectedSignerTokenBalances$: Observable<Token[]> = combineLatest([
       }))),
       map(sortReefTokenFirst),
     ))),
+  catchError((err => {
+    console.log('selectedSignerTokenBalances$ ERROR=',err.message);
+    return of(null);
+  }))
 );
 
 export const selectedSignerAddressUpdate$ = selectedSigner$.pipe(

--- a/src/graphql/apollo.ts
+++ b/src/graphql/apollo.ts
@@ -31,7 +31,6 @@ const splitLink$ = apolloUrlsSubj.pipe(
       },
       uri: urls.ws,
     });
-
     return split(
       ({ query }) => {
         const definition = getMainDefinition(query);
@@ -45,8 +44,8 @@ const splitLink$ = apolloUrlsSubj.pipe(
       httpLink,
     );
   }),
+  shareReplay(1)
 );
-
 const apolloLinksClientInstance$: Observable<ApolloClient<any>> = splitLink$.pipe(
   map(
     (splitLink) => new ApolloClient({

--- a/src/hooks/useInitReefState.ts
+++ b/src/hooks/useInitReefState.ts
@@ -2,45 +2,22 @@ import { useEffect, useState } from 'react';
 import { useObservableState } from './useObservableState';
 import { availableNetworks, Network } from '../state';
 import { useProvider } from './useProvider';
-import { currentNetwork$, setCurrentNetwork, setCurrentProvider, } from '../appState/providerState';
+import {
+  ACTIVE_NETWORK_LS_KEY,
+  currentNetwork$,
+  setCurrentNetwork,
+  setCurrentProvider,
+} from '../appState/providerState';
 import { accountsSubj } from '../appState/accountState';
 import { useLoadSigners } from './useLoadSigners';
 import { disconnectProvider } from '../utils/providerUtil';
 import { initApolloClient, State, StateOptions } from '../appState/util';
 
-const ACTIVE_NETWORK_KEY = 'reef-app-active-network';
-/*
-const getGQLUrls = (network: Network): { ws: string; http: string }|undefined => {
-  if (!network.graphqlUrl) {
-    return undefined;
-  }
-  const ws = network.graphqlUrl.startsWith('http')
-    ? network.graphqlUrl.replace('http', 'ws')
-    : network.graphqlUrl;
-  const http = network.graphqlUrl.startsWith('ws')
-    ? network.graphqlUrl.replace('ws', 'http')
-    : network.graphqlUrl;
-  return { ws, http };
-};
-
 const getNetworkFallback = (): Network => {
-  const storedNetwork = localStorage.getItem(ACTIVE_NETWORK_KEY);
+  const storedNetwork = localStorage.getItem(ACTIVE_NETWORK_LS_KEY);
   return storedNetwork != null ? JSON.parse(storedNetwork) : availableNetworks.mainnet;
 };
 
-interface State {
-  loading: boolean;
-  signers?: ReefSigner[];
-  provider?: Provider;
-  network?: Network;
-  error?: any; // TODO!
-}
-
-interface StateOptions {
-  network?: Network;
-  signers?: ReefSigner[];
-  client?: ApolloClient<any>;
-}*/
 export const useInitReefState = (
   applicationDisplayName: string,
   options: StateOptions = {},

--- a/src/hooks/useLoadSigners.ts
+++ b/src/hooks/useLoadSigners.ts
@@ -1,10 +1,11 @@
 import { Provider } from '@reef-defi/evm-provider';
 import { web3Accounts, web3Enable } from '@reef-defi/extension-dapp';
 import { InjectedExtension } from '@reef-defi/extension-inject/types';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ReefSigner } from '../state';
 import { useAsyncEffect } from './useAsyncEffect';
 import { getExtensionSigners } from '../rpc';
+import { setCurrentAddress } from '../appState/accountState';
 
 function getBrowserExtensionUrl(): string | undefined {
   const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
@@ -82,5 +83,18 @@ export const useLoadSigners = (
       setIsLoading(false);
     }
   }, [provider]);
+
+  useEffect(() => {
+    if (!signers.length) {
+      return;
+    }
+    let storedAddr = localStorage.getItem('selected_address_reef');
+    if(storedAddr && signers.some((s)=>storedAddr===s.address)){
+      setCurrentAddress(storedAddr);
+      return;
+    }
+    setCurrentAddress(signers[0].address);
+  }, [signers]);
+
   return [signers, isLoading, error];
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from '../graphql/gql';
 export * from './tokenUtil';
 export * from './transactionUtil';
 export * from './bindUtil';
+export * from './providerUtil';

--- a/src/utils/providerUtil.ts
+++ b/src/utils/providerUtil.ts
@@ -1,0 +1,14 @@
+import { Provider } from '@reef-defi/evm-provider';
+import { WsProvider } from '@polkadot/api';
+
+export async function initProvider(providerUrl: string) {
+  const newProvider = new Provider({
+    provider: new WsProvider(providerUrl),
+  });
+  await newProvider.api.isReadyOrError;
+  return newProvider;
+}
+
+export async function disconnectProvider(provider: Provider){
+  await provider.api.disconnect();
+}


### PR DESCRIPTION
`network` in `StateOptions` is now optional and should not be passed to `useInitReefState` unless in rare occasions since the default network is now loaded from localStorage. If active network is not present in localStorage hook (`useInitReefState`) then defaults to mainnet.