### PR TITLE
feat: check if amount left in the wallet is sufficient for address to exist before sending

### DIFF
--- a/src/components/Transfer/Send.css
+++ b/src/components/Transfer/Send.css
@@ -1,3 +1,9 @@
 .input-appendx-radious {
   border-radius: 5px 5px 0px 0px;
 }
+
+.existential-error {
+  font-size: 12px;
+  margin-top: 16px;
+  text-align: center;
+}

--- a/src/state/token.ts
+++ b/src/state/token.ts
@@ -1,5 +1,7 @@
 import { BigNumber } from 'ethers';
-import { ensure } from '../utils/utils';
+import {
+  EMPTY_ADDRESS, ensure, MIN_EVM_TOKEN_BALANCE, MIN_REEF_TOKEN_BALANCE, REEF_ADDRESS,
+} from '../utils/utils';
 import { calculateAmount } from '../utils/math';
 
 export enum ContractType {
@@ -72,7 +74,7 @@ export const defaultTokenState = (index = 0): TokenState => ({
 
 export const createEmptyToken = (): Token => ({
   name: 'Select token',
-  address: '0x',
+  address: EMPTY_ADDRESS,
   balance: BigNumber.from('0'),
   decimals: -1,
   iconUrl: '',
@@ -95,15 +97,31 @@ export const toTokenAmount = (
   isEmpty: false,
 });
 
+export const checkMinExistentialTokenAmount = (token: TokenWithAmount): {valid: boolean, message?: string} => {
+  const FIXED_TX_FEE = 2;
+  const isReefToken = token.address === REEF_ADDRESS;
+  const amount = calculateAmount(token);
+  const existentialMinAmount = (isReefToken ? MIN_REEF_TOKEN_BALANCE : MIN_EVM_TOKEN_BALANCE);
+  const min = calculateAmount({ decimals: token.decimals, amount: (existentialMinAmount + FIXED_TX_FEE).toString() });
+  const sum = BigNumber.from(min).add(BigNumber.from(amount));
+  const valid = BigNumber.from(token.balance).gte(sum);
+  const message = valid ? '' : `At least ${existentialMinAmount} ${token.name} tokens should be left in the wallet after transaction.`;
+  return { valid, message };
+};
+
 export const ensureTokenAmount = (token: TokenWithAmount): void => ensure(
   BigNumber.from(calculateAmount(token)).lte(token.balance),
   `Insufficient ${token.name} balance`,
 );
 
+export const ensureExistentialTokenAmount = (token: TokenWithAmount): void => {
+  ensure(checkMinExistentialTokenAmount(token).valid, `Insufficient ${token.name} balance.`);
+};
+
 export const reefTokenWithAmount = (): TokenWithAmount => toTokenAmount(
   {
     name: 'REEF',
-    address: '0x0000000000000000000000000000000001000000',
+    address: REEF_ADDRESS,
     iconUrl: 'https://s2.coinmarketcap.com/static/img/coins/64x64/6951.png',
     balance: BigNumber.from(0),
     decimals: 18,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -6,6 +6,8 @@ import { DEFAULT_TOKEN_ICONS } from '../components/common/Icons';
 export const REEF_ADDRESS = '0x0000000000000000000000000000000001000000';
 export const EMPTY_ADDRESS = '0x';
 export const REEF_ADDRESS_SPECIFIC_STRING = '(ONLY for Reef chain!)';
+export const MIN_REEF_TOKEN_BALANCE = 1;
+export const MIN_EVM_TOKEN_BALANCE = 60;
 
 export interface ButtonStatus {
   text: string;


### PR DESCRIPTION
Status and main error message is checked with `ensureExistentialTokenAmount` which returns only
Insufficient funds error message. Additional error description is provided via
`checkMinExistentialTokenAmount` and shown only if amount is not pristine (meaning that user actually
changed it). When existential token amount is checked it is assumed that transaction fee is fixed -
2 REEF.